### PR TITLE
Fixing issue when VPN NIC MAC address setting doesn't take.

### DIFF
--- a/apps/gateway/lib/vpn/vpn.ex
+++ b/apps/gateway/lib/vpn/vpn.ex
@@ -13,10 +13,6 @@ defmodule Gateway.VPN do
     # Creates a Virtual NIC. Only actually required once.
     Interface.create
 
-    # Sets the MAC address to that expected by DHCP Server
-    # on VPN Network. Only actually required once 
-    Interface.configure_mac
-
     # Creates the local VPN Account used to connect to VPN
     # Only actually required once
     Client.account_create
@@ -29,7 +25,14 @@ defmodule Gateway.VPN do
     # Required on every startup
     Client.account_connect
  
-    # Ensures the virtual NIC goes through DHCP process on VPN
+     # Sets the MAC address to that expected by DHCP Server
+    # on VPN Network. Only actually required once. Moved it to last
+    # position as it appears that on first creation the NIC is not
+    # functioning before this is called and as a result this has no
+    # effect
+    Interface.configure_mac
+
+   # Ensures the virtual NIC goes through DHCP process on VPN
     # Required on every startup. Spawn a separate process so the system can
     # continue while dhcp client waits until Virtual adaptor is actually connected
     spawn fn ->


### PR DESCRIPTION
Moved the MAC configuration call to the last item before DHCP, to put maximum distance between creation of Virtual NIC and MAC setting.