### PR TITLE
Rectifying order of events for joining VPN

### DIFF
--- a/apps/gateway/lib/vpn/vpn.ex
+++ b/apps/gateway/lib/vpn/vpn.ex
@@ -21,17 +21,17 @@ defmodule Gateway.VPN do
     # Only actually required once
     Client.account_cert_set
 
-    # Initiates the client connection to the VPN
-    # Required on every startup
-    Client.account_connect
- 
-     # Sets the MAC address to that expected by DHCP Server
+    # Sets the MAC address to that expected by DHCP Server
     # on VPN Network. Only actually required once. Moved it to last
     # position as it appears that on first creation the NIC is not
     # functioning before this is called and as a result this has no
     # effect
     Interface.configure_mac
 
+    # Initiates the client connection to the VPN
+    # Required on every startup
+    Client.account_connect
+ 
    # Ensures the virtual NIC goes through DHCP process on VPN
     # Required on every startup. Spawn a separate process so the system can
     # continue while dhcp client waits until Virtual adaptor is actually connected


### PR DESCRIPTION
Previous 'fix' set MAC after account connects which is nonsense.